### PR TITLE
About page

### DIFF
--- a/config/staging/block.block.mappy_search.yml
+++ b/config/staging/block.block.mappy_search.yml
@@ -1,6 +1,6 @@
 uuid: cbdf229a-76a3-4501-845a-9031fe339f77
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - search
@@ -8,7 +8,7 @@ dependencies:
     - mappy
 id: mappy_search
 theme: mappy
-region: content
+region: '-1'
 weight: -1
 provider: null
 plugin: search_form_block

--- a/config/staging/block.block.sitebranding.yml
+++ b/config/staging/block.block.sitebranding.yml
@@ -9,7 +9,7 @@ dependencies:
 id: sitebranding
 theme: mappy
 region: header
-weight: null
+weight: -6
 provider: null
 plugin: system_branding_block
 settings:

--- a/config/staging/system.site.yml
+++ b/config/staging/system.site.yml
@@ -5,7 +5,7 @@ slogan: ''
 page:
   403: ''
   404: ''
-  front: node
+  front: node/6
 admin_compact_mode: false
 weight_select_max: 100
 langcode: en

--- a/docroot/themes/custom/mappy/sass/components/regions/_map.scss
+++ b/docroot/themes/custom/mappy/sass/components/regions/_map.scss
@@ -6,5 +6,5 @@
  */
 
 #map {
-  background: lightblue;
+  background: $page-background-color;
 }

--- a/docroot/themes/custom/mappy/sass/components/regions/_sidebar.scss
+++ b/docroot/themes/custom/mappy/sass/components/regions/_sidebar.scss
@@ -46,9 +46,14 @@
         text-align: left;
       }
 
-      // TODO: fix aspect ratio issue.
       img {
-        max-width: 100%;
+        display: block;
+        // Maintain aspect ratio.
+        height: 100%;
+        width: 100%;
+        max-height: 236px;
+        max-width: 360px;
+
       }
     }
   }

--- a/docroot/themes/custom/mappy/sass/components/regions/_sidebar.scss
+++ b/docroot/themes/custom/mappy/sass/components/regions/_sidebar.scss
@@ -5,7 +5,7 @@
  */
 
 .path-frontpage {
-  // Slightly different classes for /about node and marker nodes,
+  // Slightly different classes for /welcome node and marker nodes,
   // because the content is pulled into the side bar differently.
   .sidebar {
     @include box-shadow;
@@ -22,7 +22,7 @@
     .sidebar__content {
       padding: 1em;
 
-      // Hide /about node title
+      // Hide /welcome node title
       .node-title-box h2 {
         display: none;
       }

--- a/docroot/themes/custom/mappy/sass/components/regions/_sidebar.scss
+++ b/docroot/themes/custom/mappy/sass/components/regions/_sidebar.scss
@@ -5,18 +5,27 @@
  */
 
 .path-frontpage {
+  // Slightly different classes for /about node and marker nodes,
+  // because the content is pulled into the side bar differently.
   .sidebar {
     @include box-shadow;
     background: $element-background-color;
     text-align: center;
 
+    // Down arrow on mobile
     i {
       @include media($wide) {
         display: none;
       }
     }
-    .sidebar__node-content {
+
+    .sidebar__content {
       padding: 1em;
+
+      // Hide /about node title
+      .node-title-box h2 {
+        display: none;
+      }
 
       h3 {
         margin: 0;
@@ -32,8 +41,14 @@
         }
       }
 
+      .field-node--body p,
       .sidebar__node-content__body {
         text-align: left;
+      }
+
+      // TODO: fix aspect ratio issue.
+      img {
+        max-width: 100%;
       }
     }
   }

--- a/docroot/themes/custom/mappy/sass/layouts/_nodepage.scss
+++ b/docroot/themes/custom/mappy/sass/layouts/_nodepage.scss
@@ -6,31 +6,19 @@
 
 .path-node {
 
-  // Main: 10 columns on mobile, 8 columns on narrow and up.
-  main {
+  // For all nodes pages.
+  article {
+    // 10 columns on mobile, 8 columns on narrow and up.
     @include span-columns(10);
     @include shift(1);
     @include clearfix;
 
-    .field-node--photos {
-      margin-bottom: $general-spacing;
-    }
-
     @include media ($wide) {
       @include span-columns(8);
       @include shift(2);
-
-      .field-node--photos {
-        @include span-columns(4 of 8);
-      }
-
-      .field-node--body {
-        @include span-columns(4 of 8);
-      }
     }
-    // Title box: 10 columns on mobile and narrow, 6 on wide and up.
+
     .node-title-box {
-      @include span-columns(10 of 10);
       @include box-shadow;
       background-color: $element-background-color;
       border-radius: $border-radius;
@@ -43,20 +31,67 @@
         margin-top: em($navigation-height) + $general-spacing;
       }
 
-      @include media ($horizontal-bar-mode) {
-        @include span-columns(6 of 8);
-        @include shift(1 of 8);
-      }
-
       h2 {
         color: $copytext-color;
         padding-left: .5em;
         padding-right: .5em;
       }
+    }
+  }
+
+  // For Place nodes.
+  // 10 columns on mobile, 8 columns on narrow and up.
+  .node--type-place {
+
+    .field-node--photos {
+      margin-bottom: $general-spacing;
+    }
+
+    @include media ($wide) {
+      .field-node--photos {
+        @include span-columns(4 of 8);
+      }
+
+      .field-node--body {
+        @include span-columns(4 of 8);
+      }
+    }
+
+    // Title box: 10 columns on mobile and narrow, 6 on wide and up.
+    .node-title-box {
+      @include span-columns(10 of 10);
+
+      @include media ($horizontal-bar-mode) {
+        @include span-columns(6 of 8);
+        @include shift(1 of 8);
+      }
 
       .field-node--address-text {
         padding-bottom: 1.5em;
       }
+    }
+  }
+
+  // For Basic Page nodes (e.g. About).
+  .node--type-page {
+
+    // Title box: 10 columns on mobile and narrow, 8 on wide and up.
+    .node-title-box {
+      @include span-columns(10 of 10);
+
+      @include media ($horizontal-bar-mode) {
+        @include span-columns(8 of 8);
+      }
+    }
+
+    p {
+      clear: both;
+    }
+
+    img {
+      @include box-shadow;
+      margin: 3em auto;
+      max-width: 100%;
     }
   }
 }

--- a/docroot/themes/custom/mappy/templates/node.html.twig
+++ b/docroot/themes/custom/mappy/templates/node.html.twig
@@ -79,8 +79,10 @@ view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
     {% if label %}
       <h2>{{ label }}</h2>
     {% endif %}
+    {% if content.address_text %}
     <hr>
     {{ content.address_text }}
+    {% endif %}
   </div>
 
   <div{{ content_attributes.addClass('node__content') }}>

--- a/docroot/themes/custom/mappy/templates/page--front.html.twig
+++ b/docroot/themes/custom/mappy/templates/page--front.html.twig
@@ -63,7 +63,7 @@
 
 <div class="sidebar">
   <i class="fa fa-lg fa-angle-double-down"></i>
-  <div class="sidebar__content">{{ page.sidebar }}</div>
+  <div class="sidebar__content">{{ page.content }}</div>
 </div>
 
 <div id="map" class="map--front"></div>


### PR DESCRIPTION
@timstallmann 

I ended up adding two separate nodes - welcome and about. The welcome node appears in the sidebar on the front page on page load and the about node is a standalone page. I thought it made sense to separate these as the sidebar will eventually be a guide to getting started with the map and the about page would be more generally about the project.

I already added these nodes to pmp.savasdev.com, and I exported all the configuration so that's in code. 

I also refactored a bunch of the nodepage CSS to account for the differences between the basic page nodes and the place nodes. 

Thanks! :dog: :cat:
