### PR TITLE
Issue #86 add soundcloud player

### DIFF
--- a/config/staging/core.entity_form_display.node.place.default.yml
+++ b/config/staging/core.entity_form_display.node.place.default.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - field.field.node.place.address_text
-    - field.field.node.place.author_name
     - field.field.node.place.body
     - field.field.node.place.date
     - field.field.node.place.field_tags
@@ -28,13 +27,6 @@ content:
     weight: 3
     settings:
       rows: 3
-      placeholder: ''
-    third_party_settings: {  }
-  author_name:
-    type: string_textfield
-    weight: 1
-    settings:
-      size: 60
       placeholder: ''
     third_party_settings: {  }
   body:

--- a/config/staging/core.entity_form_display.node.place.default.yml
+++ b/config/staging/core.entity_form_display.node.place.default.yml
@@ -10,13 +10,12 @@ dependencies:
     - field.field.node.place.field_tags
     - field.field.node.place.location_coordinates
     - field.field.node.place.photos
-    - field.field.node.place.soundcloud_link
+    - field.field.node.place.soundcloud_url
     - node.type.place
   module:
     - datetime
     - geofield
     - image
-    - link
     - path
     - text
 id: node.place.default
@@ -88,13 +87,13 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
-  soundcloud_link:
-    type: link_default
-    weight: 6
+  soundcloud_url:
+    weight: 26
     settings:
-      placeholder_url: ''
-      placeholder_title: ''
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
+    type: string_textfield
   sticky:
     type: boolean_checkbox
     weight: 12

--- a/config/staging/core.entity_form_display.node.place.default.yml
+++ b/config/staging/core.entity_form_display.node.place.default.yml
@@ -4,16 +4,19 @@ status: true
 dependencies:
   config:
     - field.field.node.place.address_text
+    - field.field.node.place.author_name
     - field.field.node.place.body
     - field.field.node.place.date
     - field.field.node.place.field_tags
     - field.field.node.place.location_coordinates
     - field.field.node.place.photos
+    - field.field.node.place.soundcloud_link
     - node.type.place
   module:
     - datetime
     - geofield
     - image
+    - link
     - path
     - text
 id: node.place.default
@@ -23,14 +26,21 @@ mode: default
 content:
   address_text:
     type: string_textarea
-    weight: 2
+    weight: 3
     settings:
       rows: 3
       placeholder: ''
     third_party_settings: {  }
+  author_name:
+    type: string_textfield
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   body:
     type: text_textarea_with_summary
-    weight: 3
+    weight: 4
     settings:
       rows: 9
       summary_rows: 3
@@ -38,17 +48,17 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 8
+    weight: 10
     settings: {  }
     third_party_settings: {  }
   date:
     type: datetime_default
-    weight: 5
+    weight: 7
     settings: {  }
     third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete
-    weight: 6
+    weight: 8
     settings:
       match_operator: CONTAINS
       size: 60
@@ -56,31 +66,38 @@ content:
     third_party_settings: {  }
   location_coordinates:
     type: geofield_latlon
-    weight: 1
+    weight: 2
     settings:
       html5_geolocation: false
     third_party_settings: {  }
   path:
     type: path
-    weight: 11
+    weight: 13
     settings: {  }
     third_party_settings: {  }
   photos:
     type: image_image
-    weight: 4
+    weight: 5
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 9
+    weight: 11
     settings:
       display_label: true
     third_party_settings: {  }
+  soundcloud_link:
+    type: link_default
+    weight: 6
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 10
+    weight: 12
     settings:
       display_label: true
     third_party_settings: {  }
@@ -93,7 +110,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 7
+    weight: 9
     settings:
       match_operator: CONTAINS
       size: 60

--- a/config/staging/core.entity_form_display.node.place.default.yml
+++ b/config/staging/core.entity_form_display.node.place.default.yml
@@ -24,14 +24,14 @@ mode: default
 content:
   address_text:
     type: string_textarea
-    weight: 3
+    weight: 2
     settings:
       rows: 3
       placeholder: ''
     third_party_settings: {  }
   body:
     type: text_textarea_with_summary
-    weight: 4
+    weight: 3
     settings:
       rows: 9
       summary_rows: 3
@@ -39,17 +39,17 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 9
     settings: {  }
     third_party_settings: {  }
   date:
     type: datetime_default
-    weight: 7
+    weight: 6
     settings: {  }
     third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete
-    weight: 8
+    weight: 7
     settings:
       match_operator: CONTAINS
       size: 60
@@ -57,38 +57,38 @@ content:
     third_party_settings: {  }
   location_coordinates:
     type: geofield_latlon
-    weight: 2
+    weight: 1
     settings:
       html5_geolocation: false
     third_party_settings: {  }
   path:
     type: path
-    weight: 13
+    weight: 12
     settings: {  }
     third_party_settings: {  }
   photos:
     type: image_image
-    weight: 5
+    weight: 4
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 11
+    weight: 10
     settings:
       display_label: true
     third_party_settings: {  }
   soundcloud_url:
-    weight: 26
+    type: string_textfield
+    weight: 5
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
   sticky:
     type: boolean_checkbox
-    weight: 12
+    weight: 11
     settings:
       display_label: true
     third_party_settings: {  }
@@ -101,7 +101,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 9
+    weight: 8
     settings:
       match_operator: CONTAINS
       size: 60

--- a/config/staging/core.entity_view_display.node.place.default.yml
+++ b/config/staging/core.entity_view_display.node.place.default.yml
@@ -10,12 +10,12 @@ dependencies:
     - field.field.node.place.field_tags
     - field.field.node.place.location_coordinates
     - field.field.node.place.photos
-    - field.field.node.place.soundcloud_link
+    - field.field.node.place.soundcloud_url
     - node.type.place
   module:
     - datetime
     - geofield
-    - link
+    - image
     - text
     - user
 id: node.place.default
@@ -75,15 +75,11 @@ content:
       image_link: ''
     third_party_settings: {  }
     label: visually_hidden
-  soundcloud_link:
-    type: link
+  soundcloud_url:
     weight: 8
+    label: above
     settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
+      link_to_entity: false
     third_party_settings: {  }
-    label: hidden
+    type: string
 hidden: {  }

--- a/config/staging/core.entity_view_display.node.place.default.yml
+++ b/config/staging/core.entity_view_display.node.place.default.yml
@@ -4,15 +4,18 @@ status: true
 dependencies:
   config:
     - field.field.node.place.address_text
+    - field.field.node.place.author_name
     - field.field.node.place.body
     - field.field.node.place.date
     - field.field.node.place.field_tags
     - field.field.node.place.location_coordinates
     - field.field.node.place.photos
+    - field.field.node.place.soundcloud_link
     - node.type.place
   module:
     - datetime
     - geofield
+    - link
     - text
     - user
 id: node.place.default
@@ -22,40 +25,65 @@ mode: default
 content:
   address_text:
     type: basic_string
-    weight: 107
+    weight: 7
     settings: {  }
     third_party_settings: {  }
     label: visually_hidden
+  author_name:
+    type: string
+    weight: 1
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    label: hidden
   body:
     type: text_default
-    weight: 101
+    weight: 2
     settings: {  }
     third_party_settings: {  }
     label: hidden
   date:
     type: datetime_default
-    weight: 103
+    weight: 4
     settings:
       format_type: medium
     third_party_settings: {  }
     label: above
   field_tags:
     type: entity_reference_label
-    weight: 106
+    weight: 6
     settings:
       link: true
     third_party_settings: {  }
     label: above
   links:
-    weight: 100
+    weight: 0
     settings: {  }
     third_party_settings: {  }
   location_coordinates:
     type: geofield_default
-    weight: 105
+    weight: 5
     settings:
       output_format: wkt
     third_party_settings: {  }
     label: above
-hidden:
-  photos: true
+  photos:
+    type: image
+    weight: 3
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
+    label: visually_hidden
+  soundcloud_link:
+    type: link
+    weight: 8
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    label: hidden
+hidden: {  }

--- a/config/staging/core.entity_view_display.node.place.default.yml
+++ b/config/staging/core.entity_view_display.node.place.default.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - field.field.node.place.address_text
-    - field.field.node.place.author_name
     - field.field.node.place.body
     - field.field.node.place.date
     - field.field.node.place.field_tags
@@ -29,13 +28,6 @@ content:
     settings: {  }
     third_party_settings: {  }
     label: visually_hidden
-  author_name:
-    type: string
-    weight: 1
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    label: hidden
   body:
     type: text_default
     weight: 2

--- a/config/staging/core.entity_view_display.node.place.teaser.yml
+++ b/config/staging/core.entity_view_display.node.place.teaser.yml
@@ -11,7 +11,6 @@ dependencies:
     - field.field.node.place.field_tags
     - field.field.node.place.location_coordinates
     - field.field.node.place.photos
-    - field.field.node.place.soundcloud_link
     - node.type.place
   module:
     - text
@@ -37,4 +36,3 @@ hidden:
   field_tags: true
   location_coordinates: true
   photos: true
-  soundcloud_link: true

--- a/config/staging/core.entity_view_display.node.place.teaser.yml
+++ b/config/staging/core.entity_view_display.node.place.teaser.yml
@@ -5,11 +5,13 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.place.address_text
+    - field.field.node.place.author_name
     - field.field.node.place.body
     - field.field.node.place.date
     - field.field.node.place.field_tags
     - field.field.node.place.location_coordinates
     - field.field.node.place.photos
+    - field.field.node.place.soundcloud_link
     - node.type.place
   module:
     - text
@@ -30,7 +32,9 @@ content:
     weight: 100
 hidden:
   address_text: true
+  author_name: true
   date: true
   field_tags: true
   location_coordinates: true
   photos: true
+  soundcloud_link: true

--- a/config/staging/field.field.node.place.soundcloud_url.yml
+++ b/config/staging/field.field.node.place.soundcloud_url.yml
@@ -1,0 +1,21 @@
+uuid: 8d96ff0b-86a7-413d-b054-84d4fe2a8d5c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.soundcloud_url
+    - node.type.place
+id: node.place.soundcloud_url
+field_name: soundcloud_url
+entity_type: node
+bundle: place
+label: 'SoundCloud URL'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/staging/field.storage.node.soundcloud_url.yml
+++ b/config/staging/field.storage.node.soundcloud_url.yml
@@ -1,0 +1,19 @@
+uuid: 13f823f9-f847-4823-ad00-f69d00fc6bf3
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.soundcloud_url
+field_name: soundcloud_url
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false

--- a/docroot/themes/custom/mappy/sass/components/regions/_soundcloud-player.scss
+++ b/docroot/themes/custom/mappy/sass/components/regions/_soundcloud-player.scss
@@ -1,0 +1,12 @@
+.field-node--soundcloud-url {
+  @include box-shadow;
+}
+
+.field-node--soundcloud-url, .field-node--soundcloud-url iframe {
+  height: 160px;
+
+  @include media(em(400)) {
+    height: 160px;
+    width: 320px;
+  }
+}

--- a/docroot/themes/custom/mappy/sass/layouts/_nodepage.scss
+++ b/docroot/themes/custom/mappy/sass/layouts/_nodepage.scss
@@ -41,13 +41,18 @@
     .node__content {
       clear: both;
 
-      .view-photo-slideshow {
+      .view-photo-slideshow,
+      .field-node--soundcloud-url {
         margin: 0 auto $general-spacing;
       }
 
       @include media ($x-wide) {
-        .view-photo-slideshow {
+        .node-left-pane {
           float: left;
+        }
+
+        .view-photo-slideshow,
+        .field-node--soundcloud-url {
           margin: 0 1em 1em 0;
         }
 

--- a/docroot/themes/custom/mappy/sass/layouts/_nodepage.scss
+++ b/docroot/themes/custom/mappy/sass/layouts/_nodepage.scss
@@ -53,7 +53,7 @@
 
         .view-photo-slideshow,
         .field-node--soundcloud-url {
-          margin: 0 1em 1em 0;
+          margin: 0 2em 1em 0;
         }
 
         p {

--- a/docroot/themes/custom/mappy/sass/styles.scss
+++ b/docroot/themes/custom/mappy/sass/styles.scss
@@ -27,6 +27,7 @@
 @import "components/regions/map";
 @import "components/regions/footer";
 @import "components/regions/photo-slideshow";
+@import "components/regions/soundcloud-player";
 
 @import "components/nodepage";
 @import "components/page";

--- a/docroot/themes/custom/mappy/templates/field--node--soundcloud-link.html.twig
+++ b/docroot/themes/custom/mappy/templates/field--node--soundcloud-link.html.twig
@@ -1,4 +1,0 @@
-{#
-#}
-
-<iframe width="100%" height="250" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/64065412&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;visual=true"></iframe>

--- a/docroot/themes/custom/mappy/templates/field--node--soundcloud-link.html.twig
+++ b/docroot/themes/custom/mappy/templates/field--node--soundcloud-link.html.twig
@@ -1,0 +1,4 @@
+{#
+#}
+
+<iframe width="100%" height="250" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/64065412&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;visual=true"></iframe>

--- a/docroot/themes/custom/mappy/templates/field--node--soundcloud-url.html.twig
+++ b/docroot/themes/custom/mappy/templates/field--node--soundcloud-url.html.twig
@@ -1,0 +1,6 @@
+{#
+#}
+
+<div class="field-node--soundcloud-url">
+<iframe width="300" height="150" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url={{ element }}&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;visual=true"></iframe>
+</div>

--- a/docroot/themes/custom/mappy/templates/node.html.twig
+++ b/docroot/themes/custom/mappy/templates/node.html.twig
@@ -89,6 +89,7 @@ view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
     {% if node.bundle == 'place' %}
       {{ photo_slideshow_view }}
     {% endif %}
+	{{ content.soundcloud_link }}
 
     {{ content.body }}
   </div>

--- a/docroot/themes/custom/mappy/templates/node.html.twig
+++ b/docroot/themes/custom/mappy/templates/node.html.twig
@@ -87,11 +87,13 @@ view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
 
   <div{{ content_attributes.addClass('node__content') }}>
     {% if node.bundle == 'place' %}
-      {{ photo_slideshow_view }}
+      <div class="node-left-pane">
+        {{ photo_slideshow_view }}
+        {{ content.soundcloud_url }}
+      </div>
     {% endif %}
-	{{ content.soundcloud_link }}
-
     {{ content.body }}
+
   </div>
 
   {% if content.links %}


### PR DESCRIPTION
@AnneTee this adds a new content field "SoundCloud URL" and renders it using the embedded iframe as a soundcloud player link. 

One big caveat is I have no idea what kind of sanitizations / checks are being performed on this text field before it gets output right into an iframe URL (thus it potentially creates a vulnerability where a user with permission to edit content could input malicious code via this field) . I tried running the field through the `url_encode` filter, but got garbage results out. If you have any thoughts on how to do that via twig I'd love to hear it!!

Also not sure if adding this new node left pane makes sense and if it is SMACCS / BEM friendly.

To test:
- Import config
- Recompile SASS
- Edit a node and add the "share" link to a soundcloud file to the SoundCloud URL field. Example: `https://soundcloud.com/pauli-murray-project/pauli-murray-denied-entry-to-unc`
