### PR TITLE
Issue #296: Disable new account creation by non-admins, create contributor and editor roles, set some basic permissions

### DIFF
--- a/config/staging/contact.settings.yml
+++ b/config/staging/contact.settings.yml
@@ -1,0 +1,1 @@
+user_default_enabled: false

--- a/config/staging/system.action.user_add_role_action.editor.yml
+++ b/config/staging/system.action.user_add_role_action.editor.yml
@@ -1,0 +1,14 @@
+uuid: e40396d6-a2e5-463d-8200-dffa9cd9dbc1
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.editor
+  module:
+    - user
+id: user_add_role_action.editor
+label: 'Add the Editor role to the selected users'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: editor

--- a/config/staging/system.action.user_remove_role_action.editor.yml
+++ b/config/staging/system.action.user_remove_role_action.editor.yml
@@ -1,0 +1,14 @@
+uuid: 6063ba40-105f-44f5-8a59-893fffd34bb6
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.editor
+  module:
+    - user
+id: user_remove_role_action.editor
+label: 'Remove the Editor role from the selected users'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: editor

--- a/config/staging/system.site.yml
+++ b/config/staging/system.site.yml
@@ -10,3 +10,4 @@ admin_compact_mode: false
 weight_select_max: 100
 langcode: en
 default_langcode: en
+mail_notification: ''

--- a/config/staging/user.mail.yml
+++ b/config/staging/user.mail.yml
@@ -1,28 +1,28 @@
 cancel_confirm:
-  body: "[user:name],\n\nA request to cancel your account has been made at [site:name].\n\nYou may now cancel your account on [site:url-brief] by clicking this link or copying and pasting it into your browser:\n\n[user:cancel-url]\n\nNOTE: The cancellation of your account is not reversible.\n\nThis link expires in one day and nothing will happen if it is not used.\n\n--  [site:name] team"
+  body: "[user:name],\r\n\r\nA request to cancel your account has been made at [site:name].\r\n\r\nYou may now cancel your account on [site:url-brief] by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:cancel-url]\r\n\r\nNOTE: The cancellation of your account is not reversible.\r\n\r\nThis link expires in one day and nothing will happen if it is not used.\r\n\r\n--  [site:name] team"
   subject: 'Account cancellation request for [user:name] at [site:name]'
 password_reset:
-  body: "[user:name],\n\nA request to reset the password for your account has been made at [site:name].\n\nYou may now log in by clicking this link or copying and pasting it to your browser:\n\n[user:one-time-login-url]\n\nThis link can only be used once to log in and will lead you to a page where you can set your password. It expires after one day and nothing will happen if it's not used.\n\n--  [site:name] team"
+  body: "[user:name],\r\n\r\nA request to reset the password for your account has been made at [site:name].\r\n\r\nYou may now log in by clicking this link or copying and pasting it to your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password. It expires after one day and nothing will happen if it's not used.\r\n\r\n--  [site:name] team"
   subject: 'Replacement login information for [user:name] at [site:name]'
 register_admin_created:
-  body: "[user:name],\n\nA site administrator at [site:name] has created an account for you. You may now log in by clicking this link or copying and pasting it to your browser:\n\n[user:one-time-login-url]\n\nThis link can only be used once to log in and will lead you to a page where you can set your password.\n\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\n\nusername: [user:name]\npassword: Your password\n\n--  [site:name] team"
+  body: "[user:name],\r\n\r\nA site administrator at [site:name] has created an account for you. You may now log in by clicking this link or copying and pasting it to your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\r\n\r\nusername: [user:name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
   subject: 'An administrator created an account for you at [site:name]'
 register_no_approval_required:
-  body: "[user:name],\n\nThank you for registering at [site:name]. You may now log in by clicking this link or copying and pasting it to your browser:\n\n[user:one-time-login-url]\n\nThis link can only be used once to log in and will lead you to a page where you can set your password.\n\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\n\nusername: [user:name]\npassword: Your password\n\n--  [site:name] team"
+  body: "[user:name],\r\n\r\nThank you for registering at [site:name]. You may now log in by clicking this link or copying and pasting it to your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\r\n\r\nusername: [user:name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
   subject: 'Account details for [user:name] at [site:name]'
 register_pending_approval:
-  body: "[user:name],\n\nThank you for registering at [site:name]. Your application for an account is currently pending approval. Once it has been approved, you will receive another email containing information about how to log in, set your password, and other details.\n\n\n--  [site:name] team"
+  body: "[user:name],\r\n\r\nThank you for registering at [site:name]. Your application for an account is currently pending approval. Once it has been approved, you will receive another email containing information about how to log in, set your password, and other details.\r\n\r\n\r\n--  [site:name] team"
   subject: 'Account details for [user:name] at [site:name] (pending admin approval)'
 register_pending_approval_admin:
   body: "[user:name] has applied for an account.\n\n[user:edit-url]"
   subject: 'Account details for [user:name] at [site:name] (pending admin approval)'
 status_activated:
-  body: "[user:name],\n\nYour account at [site:name] has been activated.\n\nYou may now log in by clicking this link or copying and pasting it into your browser:\n\n[user:one-time-login-url]\n\nThis link can only be used once to log in and will lead you to a page where you can set your password.\n\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\n\nusername: [user:name]\npassword: Your password\n\n--  [site:name] team"
+  body: "[user:name],\r\n\r\nYour account at [site:name] has been activated.\r\n\r\nYou may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\r\n\r\nusername: [user:name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
   subject: 'Account details for [user:name] at [site:name] (approved)'
 status_blocked:
-  body: "[user:name],\n\nYour account on [site:name] has been blocked.\n\n--  [site:name] team"
+  body: "[user:name],\r\n\r\nYour account on [site:name] has been blocked.\r\n\r\n--  [site:name] team"
   subject: 'Account details for [user:name] at [site:name] (blocked)'
 status_canceled:
-  body: "[user:name],\n\nYour account on [site:name] has been canceled.\n\n--  [site:name] team"
+  body: "[user:name],\r\n\r\nYour account on [site:name] has been canceled.\r\n\r\n--  [site:name] team"
   subject: 'Account details for [user:name] at [site:name] (canceled)'
 langcode: en

--- a/config/staging/user.role.administrator.yml
+++ b/config/staging/user.role.administrator.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: administrator
-label: Administrator
+label: 'System Administrator'
 weight: 2
 is_admin: true
 permissions: {  }

--- a/config/staging/user.role.authenticated.yml
+++ b/config/staging/user.role.authenticated.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: authenticated
-label: 'Authenticated user'
+label: Contributor
 weight: 1
 is_admin: false
 permissions:
@@ -16,3 +16,11 @@ permissions:
   - 'access site-wide contact form'
   - 'access shortcuts'
   - 'search content'
+  - 'view own unpublished content'
+  - 'create place content'
+  - 'delete own place content'
+  - 'edit any place content'
+  - 'edit own place content'
+  - 'revert place revisions'
+  - 'view place revisions'
+  - 'view the administration theme'

--- a/config/staging/user.role.editor.yml
+++ b/config/staging/user.role.editor.yml
@@ -1,0 +1,48 @@
+uuid: ab1a2558-efd3-4875-9f0e-147eeb758077
+langcode: en
+status: true
+dependencies: {  }
+id: editor
+label: Editor
+weight: 3
+is_admin: null
+permissions:
+  - 'administer comments'
+  - 'edit own comments'
+  - 'post comments'
+  - 'skip comment approval'
+  - 'access comments'
+  - 'access files overview'
+  - 'use text format basic_html'
+  - 'use text format full_html'
+  - 'use text format plain_text'
+  - 'use text format restricted_html'
+  - 'administer image styles'
+  - 'access content overview'
+  - 'administer nodes'
+  - 'bypass node access'
+  - 'delete all revisions'
+  - 'revert all revisions'
+  - 'view all revisions'
+  - 'view own unpublished content'
+  - 'access content'
+  - 'edit any article content'
+  - 'edit own article content'
+  - 'edit any page content'
+  - 'edit own page content'
+  - 'create place content'
+  - 'delete any place content'
+  - 'delete own place content'
+  - 'delete place revisions'
+  - 'edit any place content'
+  - 'edit own place content'
+  - 'revert place revisions'
+  - 'view place revisions'
+  - 'access in-place editing'
+  - 'search content'
+  - 'access site reports'
+  - 'view the administration theme'
+  - 'administer taxonomy'
+  - 'delete terms in tags'
+  - 'edit terms in tags'
+  - 'access toolbar'

--- a/config/staging/user.settings.yml
+++ b/config/staging/user.settings.yml
@@ -1,1 +1,9 @@
-register: visitors_admin_approval
+register: admin_only
+anonymous: Anonymous
+password_strength: false
+verify_mail: false
+cancel_method: null
+notify:
+  status_activated: false
+  status_blocked: false
+  status_canceled: false


### PR DESCRIPTION
This PR disables account creation except by admins, creates a new "Editor" role for non-sys-admins (mainly so they can't accidentally mess up settings unintentionally), and takes a first pass at assigning logical permissions to the different roles:
- System Administrators (all permissions)
- Editors - should be able to add/delete users, edit & delete content, edit text in blocks on the page, etc., but not mess with system settings
- Contributors - should be able to create & edit places

I'd love a second opinion on the permissions choices here!
