### PR TITLE
Issue #204: Configure metatag and add metatag field to basic page type

### DIFF
--- a/sites/default/config/core.entity_form_display.node.page.default.yml
+++ b/sites/default/config/core.entity_form_display.node.page.default.yml
@@ -4,8 +4,10 @@ status: true
 dependencies:
   config:
     - field.field.node.page.body
+    - field.field.node.page.field_metatag
     - node.type.page
   module:
+    - metatag
     - path
     - text
 _core:
@@ -28,6 +30,11 @@ content:
     weight: 10
     settings: {  }
     third_party_settings: {  }
+  field_metatag:
+    weight: 32
+    settings: {  }
+    third_party_settings: {  }
+    type: metatag_firehose
   path:
     type: path
     weight: 30

--- a/sites/default/config/core.entity_view_display.node.page.default.yml
+++ b/sites/default/config/core.entity_view_display.node.page.default.yml
@@ -4,8 +4,10 @@ status: true
 dependencies:
   config:
     - field.field.node.page.body
+    - field.field.node.page.field_metatag
     - node.type.page
   module:
+    - metatag
     - text
     - user
 _core:
@@ -21,6 +23,12 @@ content:
     weight: 100
     settings: {  }
     third_party_settings: {  }
+  field_metatag:
+    weight: 102
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: metatag_empty_formatter
   links:
     weight: 101
 hidden: {  }

--- a/sites/default/config/field.field.node.page.field_metatag.yml
+++ b/sites/default/config/field.field.node.page.field_metatag.yml
@@ -1,0 +1,23 @@
+uuid: 5b44fe67-4120-46f8-bc0c-12b0dca08ce2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_metatag
+    - node.type.page
+  module:
+    - metatag
+id: node.page.field_metatag
+field_name: field_metatag
+entity_type: node
+bundle: page
+label: Metatag
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 'a:2:{s:5:"title";s:34:"[current-page:title] | [site:name]";s:9:"image_src";s:97:"http://www.durhamcivilrightsmap.org/sites/default/files/civil-rights-map-frontpage-screenshot.jpg";}'
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/sites/default/config/field.storage.node.field_metatag.yml
+++ b/sites/default/config/field.storage.node.field_metatag.yml
@@ -1,0 +1,19 @@
+uuid: 9f8f8f24-2870-4930-9e09-9d682d84d3fd
+langcode: en
+status: true
+dependencies:
+  module:
+    - metatag
+    - node
+id: node.field_metatag
+field_name: field_metatag
+entity_type: node
+type: metatag
+settings: {  }
+module: metatag
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/sites/default/config/metatag.metatag_defaults.front.yml
+++ b/sites/default/config/metatag.metatag_defaults.front.yml
@@ -8,4 +8,7 @@ id: front
 label: 'Front page'
 tags:
   canonical_url: '[site:url]'
+  description: 'Map documenting civil and human rights activism in Durham, NC, by the Pauli Murray Project and Savas Labs.'
+  image_src: 'http://www.durhamcivilrightsmap.org/sites/default/files/civil-rights-map-frontpage-screenshot.jpg'
   shortlink: '[site:url]'
+  title: 'Durham Civil and Human Rights History Map'

--- a/sites/default/config/metatag.metatag_defaults.global.yml
+++ b/sites/default/config/metatag.metatag_defaults.global.yml
@@ -7,4 +7,5 @@ _core:
 id: global
 label: Global
 tags:
+  image_src: 'http://www.durhamcivilrightsmap.org/sites/default/files/civil-rights-map-frontpage-screenshot.jpg'
   title: '[current-page:title] | [site:name]'

--- a/sites/default/config/metatag.metatag_defaults.node.yml
+++ b/sites/default/config/metatag.metatag_defaults.node.yml
@@ -7,5 +7,6 @@ _core:
 id: node
 label: Content
 tags:
-  title: '[node:title] | [site:name]'
   description: '[node:summary]'
+  image_src: '[node:field_photos]'
+  title: '[node:title] | [site:name]'

--- a/sites/default/config/metatag.metatag_defaults.taxonomy_term.yml
+++ b/sites/default/config/metatag.metatag_defaults.taxonomy_term.yml
@@ -7,5 +7,6 @@ _core:
 id: taxonomy_term
 label: 'Taxonomy term'
 tags:
-  title: '[term:name] | [site:name]'
   description: '[term:description]'
+  image_src: 'http://www.durhamcivilrightsmap.org/sites/default/files/civil-rights-map-frontpage-screenshot.jpg'
+  title: '[term:name] | [site:name]'


### PR DESCRIPTION
This PR:
- Configures site-wide metatags to add the first photo from field_photos as the image url for place nodes
- Adds field_metatag to the basic page content type as a workaround for https://www.drupal.org/node/2650408
- Sets the default image metatag to http://www.durhamcivilrightsmap.org/sites/default/files/civil-rights-map-frontpage-screenshot.jpg which I just quickly created via a screen capture. We could use a snazzier image here potentially.

Manual config steps:
Once this is deployed, you need to edit the `Welcome` page metatags to be as follows:
Page title: `Durham Civil and Human Rights History Map`
Description: `Map documenting civil and human rights activism in Durham, NC. Made by the Pauli Murray Project and Savas Labs.`
