### PR TITLE
Add events to ga tracking

### DIFF
--- a/themes/custom/mappy/js/page--front--map.js
+++ b/themes/custom/mappy/js/page--front--map.js
@@ -33,6 +33,12 @@
           // I don't know why it's called 'nothing,' nor how to change
           // it, but this is the entire node display.
           $("div.sidebar__content").html(feature.properties.nothing);
+          ga('send', {
+            hitType: 'event',
+            eventCategory: 'Map',
+            eventAction: 'click',
+            eventLabel: feature.properties.name
+          });
         });
       }
     });
@@ -54,6 +60,14 @@
   $.getJSON('/points?_format=json', function (data) {
     addDataToMap(data, map, new pmpIcon);
     searchCtrl.indexFeatures(data, ['title_1', 'field_address_text', 'description', 'field_tags']);
+    ga('send', {
+      hitType: 'event',
+      eventCategory: 'Map',
+      eventAction: 'loaded',
+      eventLabel: 'Map JSON loaded',
+      nonInteraction: true
+    });
+
   });
 
   // Add zoom controls in bottom right of map.


### PR DESCRIPTION
Because the main page load is the map itself, user interactions with the map are not being logged to GA. This PR attempts to add event-specific tracking to track map clicks, but I have no idea how to test it locally (besides noting that it is not breaking anything).

@AnneTee do you wanna test this and also make sure it doesn't break anything? @kostajh any thoughts on whether this code should work or how to test?
